### PR TITLE
CTV servers no longer have the escape() function around article descriptions, this was causing a crash on the plugin

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -1,5 +1,5 @@
 RE_CLIPID   = Regex('clip.id = ([0-9]+)')
-RE_SUMMARY  = Regex('clip.description = escape\("(.+)"\);')
+RE_SUMMARY  = Regex('clip.description = "(.+)"')
 
 CTV_URL         = 'http://www.ctvnews.ca/video'
 VIDEO_URL       = 'http://www.ctvnews.ca/video?clipId=%s&binId=%s'


### PR DESCRIPTION
Exception trace:

2013-01-06 15:09:11,084 (1090) :  CRITICAL (core:561) - Exception when calling function 'SectionMenu' (most recent call last):
  File "C:\Users\johne\AppData\Local\Plex Media Server\Plug-ins\Framework.bundle\Contents\Resources\Versions\2\Python\Framework\code\sandbox.py", line 294, in call_named_function
    result = f(_args, *_kwargs)
  File "C:\Users\johne\AppData\Local\Plex Media Server\Plug-ins\CTV News.bundle\Contents\Code__init__.py", line 40, in SectionMenu
    summary = RE_SUMMARY.search(details).group(1)
AttributeError: 'NoneType' object has no attribute 'group'

the 'details' variable contained:

```
        // create clip object

        var clip = new Object();

        clip.id = 837962;

        clip.title = "News headlines from CTV News Channel";

        clip.image = "http://www.ctvnews.ca/polopoly_fs/1.846393!/httpImage/image.jpg_gen/derivatives/landscape_960/image.jpg";

        clip.description = "Latest breaking news headlines from CTV News Channel.";

        playlistMap['1.821148'].push(clip);
```

Regex extraction on group(1) was failing because there is no escape(); function around the clip description
